### PR TITLE
Allow backorders not supported on main products page

### DIFF
--- a/app/views/products/_variant_options.html.erb
+++ b/app/views/products/_variant_options.html.erb
@@ -14,7 +14,7 @@
             <% if variants.empty? %>
               <% classes << "unavailable" %>
             <% else %>
-              <% classes << (variants.sum(&:count_on_hand) < 1 ? "out-of-stock" : "in-stock") %>
+              <% classes << ( Spree::Config[:allow_backorders] || variants.sum(&:count_on_hand) > 0 ? "in-stock" : "out-of-stock" ) %>
             <% end %>
           <% end %>
           <li>       


### PR DESCRIPTION
When browsing products you cannot choose options when allow_backorders is turned on.  Changed so that it shows the product as variant as in stock.
