### PR TITLE
refactored option_values querying using scope

### DIFF
--- a/app/models/spree/option_value_decorator.rb
+++ b/app/models/spree/option_value_decorator.rb
@@ -1,15 +1,17 @@
 Spree::OptionValue.class_eval do
 
-  default_scope order(:position)
-    
-  has_attached_file :image, 
+  default_scope order("#{quoted_table_name}.position")
+
+  has_attached_file :image,
     :styles        => { :small => '40x30#', :large => '140x110#' },
     :default_style => :small,
     :url           => "/spree/option_values/:id/:style/:basename.:extension",
     :path          => ":rails_root/public/spree/option_values/:id/:style/:basename.:extension"
-    
+
   def has_image?
     image_file_name && !image_file_name.empty?
   end
-  
+
+  scope :for_product, lambda { |product| select("DISTINCT #{table_name}.*").where("spree_option_values_variants.variant_id IN (?)", product.variant_ids).joins(:variants)
+  }
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,18 +1,18 @@
 Spree::Product.class_eval do
 
   def option_values
-    @_option_values ||= variants.includes(:option_values).map(&:option_values).flatten.uniq.sort_by {|ov| ov.option_type.position }
+    @_option_values ||= Spree::OptionValue.for_product(self).sort_by {|ov| ov.option_type.position }
   end
-  
+
   def grouped_option_values
     @_grouped_option_values ||= option_values.group_by(&:option_type)
   end
-    
-  def variants_for_option_value(value)    
+
+  def variants_for_option_value(value)
     @_variant_option_values ||= variants.includes(:option_values).all
     @_variant_option_values.select { |i| i.option_value_ids.include?(value.id) }
   end
-  
+
   def variant_options_hash
     return @_variant_options_hash if @_variant_options_hash
     hash = {}
@@ -27,5 +27,5 @@ Spree::Product.class_eval do
     end
     @_variant_options_hash = hash
   end
-  
+
 end

--- a/test/unit/spree/option_value_test.rb
+++ b/test/unit/spree/option_value_test.rb
@@ -74,5 +74,9 @@ class Spree::OptionValueTest < ActiveSupport::TestCase
       assert !@unordered
     end
 
+    should "return empty array when no variants" do
+      product = Factory(:product)
+      assert_equal [], Spree::OptionValue.for_product(product)
+    end
   end
 end

--- a/test/unit/spree/option_value_test.rb
+++ b/test/unit/spree/option_value_test.rb
@@ -7,51 +7,72 @@ class Spree::OptionValueTest < ActiveSupport::TestCase
   end
 
   should_have_attached_file :image
-  
+
   context "a new option value" do
-  
+
     setup do
       @option_value = Spree::OptionValue.new
     end
-  
+
     should "not have an image" do
       assert !@option_value.has_image?
     end
-  
+
   end
-  
+
   context "an existing option value" do
-  
+
     setup do
       @option_value = Factory.create(:option_value)
     end
-  
+
     should "not have an image" do
       assert !@option_value.has_image?
     end
-    
+
     context "with an image" do
-      
+
       setup do
         @path = @images.shuffle.first
         file = File.open(@path)
         @option_value.update_attributes(:image => file)
         file.close
       end
-      
+
       should "have an image" do
         assert @option_value.has_image?
       end
-      
+
       should "have small large and original images" do
         dir = File.expand_path("../../../dummy/public/spree/option_values/#{@option_value.id}", __FILE__)
         %w(small large original).each do |size|
           assert File.exists?(File.join(dir, size, File.basename(@path)))
-        end        
+        end
       end
-      
+
     end
-  
+
   end
-  
+
+  context "#for_product" do
+    setup do
+      @product = Factory.create(:product_with_variants)
+    end
+
+    should "return uniq option_values" do
+      unused = Factory(:option_value, :option_type => @product.option_types.first, :presentation => "Unused")
+      assert !Spree::OptionValue.for_product(@product).include?(unused)
+    end
+
+    should "retain option values sort order" do
+      @unordered, @prev_position = false, 0
+      Spree::OptionValue.for_product(@product).all.each do |ov|
+        @unordered = true if @prev_position > ov.position
+        @prev_position = ov.position
+      end
+
+      assert !@unordered
+    end
+
+  end
 end

--- a/test/unit/spree/product_test.rb
+++ b/test/unit/spree/product_test.rb
@@ -5,45 +5,34 @@ class Spree::ProductTest < ActiveSupport::TestCase
   setup do
     @methods = %w(option_values grouped_option_values variant_options_hash)
   end
-  
+
   context "any product" do
-  
+
     setup do
       @product = Factory.create(:product)
     end
-  
+
     should "have proper methods" do
       @methods.each do |m|
         assert @product.respond_to?(m)
       end
     end
-        
+
   end
-  
-  
+
+
   context "a product with variants" do
-    
+
     setup do
       @product = Factory.create(:product_with_variants)
     end
-    
+
     should "have variants and option types and values" do
       assert_equal 2,  @product.option_types.count
       assert_equal 12, @product.option_values.count
       assert_equal 32, @product.variants.count
     end
-    
-    should "fetch all unique option values" do
-      unused = Factory(:option_value, :option_type => @product.option_types.first, :presentation => "Unused")
-      assert !@product.option_values.include?(unused)
-    end
-    
-    should "retain option values sort order" do
-      @product.option_types.each_with_index {|ot, i| ot.update_attribute(:position, i + 1) }
-      assert_equal [1,2], @product.option_values.map {|ov| ov.option_type.reload.position }.uniq
-      assert_equal [1,2], @product.option_values.map(&:position).uniq
-    end
-    
+
     should "have values grouped by type" do
       expected = { "size" => 4, "color" => 8 }
       assert_equal 2,  @product.grouped_option_values.count
@@ -51,7 +40,7 @@ class Spree::ProductTest < ActiveSupport::TestCase
         assert_equal expected[type.name], values.length
       end
     end
-    
+
   end
-    
+
 end


### PR DESCRIPTION
hey citrus,

I've refactored the way we query the option values by using scope instead of ruby enumerable.

Let me know what you think.
