### PR TITLE
Variable can be changed outside of the scope by mistake

### DIFF
--- a/app/assets/javascripts/store/variant_options.js
+++ b/app/assets/javascripts/store/variant_options.js
@@ -36,6 +36,7 @@ function VariantOptions(options, allow_backorders) {
   var allow_backorders = allow_backorders;
   var variant, divs, parent, index = 0;
   var selection = [];
+  var buttons; 
 
   function init() {
     divs = $('#product-variants .variant-options');


### PR DESCRIPTION
Buttons variable is a really common variable name and took me some time to find the error because a async js (unrelated with the app) use the same variable name and add other content to that one.

Set up the variable in the context of the function everything works again
