### PR TITLE
Default instock variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Spree Variant Options comes with some handy options:
 
 - allow_select_outofstock (default : false)
   When using extension like ([spree_wishlist](https://github.com/spree/spree_wishlist)), you might want to allow your customer to add out of stock product by selecting out of stock variant options :
-  ```html
+  ```erb
     <%= form_for Spree::WishedProduct.new, :html => {:"data-form-type" => "variant"} do |f| %>
       <%= f.hidden_field :variant_id, :value => @product.master.id %>
       <button type="submit" class="medium blue awesome">

--- a/app/assets/javascripts/store/variant_options.js
+++ b/app/assets/javascripts/store/variant_options.js
@@ -35,6 +35,7 @@ function VariantOptions(params) {
   var options = params['options'];
   var allow_backorders = !params['track_inventory_levels'] ||  params['allow_backorders'];
   var allow_select_outofstock = params['allow_select_outofstock'];
+  var default_instock = params['default_instock'];
 
   var variant, divs, parent, index = 0;
   var selection = [];
@@ -48,6 +49,12 @@ function VariantOptions(params) {
     enable(parent.find('a.option-value'));
     toggle();
     $('.clear-option a.clear-button').hide().click(handle_clear);
+
+    if (default_instock) {
+      divs.each(function(){
+        $(this).find("ul.variant-option-values li a.in-stock:first").click();
+      });
+    }
   }
 
   function get_index(parent) {

--- a/app/models/spree/app_configuration/variant_configuration.rb
+++ b/app/models/spree/app_configuration/variant_configuration.rb
@@ -1,5 +1,6 @@
 module SpreeVariantOptions
   class VariantConfiguration < Spree::Preferences::Configuration
     preference :allow_select_outofstock, :boolean, :default => false
+    preference :default_instock, :boolean, :default => false
   end
 end

--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -1,3 +1,4 @@
+<%= debug SpreeVariantOptions::VariantConfig.allow_select_outofstock %>
 <% if @product.has_variants? %>
   <div id="product-variants">
     <h2><%= t('variants') %></h2>
@@ -26,7 +27,8 @@
         options: <%== @product.variant_options_hash.to_json -%>,
         track_inventory_levels: <%==  !!Spree::Config[:track_inventory_levels] -%>,
         allow_backorders: <%==  !!Spree::Config[:allow_backorders] -%>,
-        allow_select_outofstock: <%== !!SpreeVariantOptions::VariantConfig[:allow_select_outofstock] -%>
+        allow_select_outofstock: <%== !!SpreeVariantOptions::VariantConfig[:allow_select_outofstock] -%>,
+        default_instock: <%== !!SpreeVariantOptions::VariantConfig[:default_instock] -%>
       });
     //]]>
     </script>

--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -1,4 +1,3 @@
-<%= debug SpreeVariantOptions::VariantConfig.allow_select_outofstock %>
 <% if @product.has_variants? %>
   <div id="product-variants">
     <h2><%= t('variants') %></h2>

--- a/test/integration/variant_test.rb
+++ b/test/integration/variant_test.rb
@@ -16,6 +16,7 @@ end
 class ProductTest < ActionDispatch::IntegrationTest
 
   context 'with track inventory levels' do
+
     setup do
       Spree::Config[:track_inventory_levels] = true
       Spree::Config[:allow_backorders] = false
@@ -34,113 +35,124 @@ class ProductTest < ActionDispatch::IntegrationTest
       Deface::Override.new( :virtual_path => "spree/products/show",
       :name => "add_other_form_to_spree_variant_options",
       :insert_after => "div#cart-form",
-      :text => %q{
-        <div id="wishlist-form">
-        <%= form_for Spree::WishedProduct.new, :url => "foo", :html => {:"data-form-type" => "variant"} do |f| %>
-          <%= f.hidden_field :variant_id, :value => @product.master.id %>
-          <button type="submit">
-          <%= t(:add_to_wishlist) %>
-          </button>
-          <% end %>
-          </div>
-        }
-        )
+      :text => '<div id="wishlist-form"><%= form_for Spree::WishedProduct.new, :url => "foo", :html => {:"data-form-type" => "variant"} do |f| %><%= f.hidden_field :variant_id, :value => @product.master.id %><button type="submit"><%= t(:add_to_wishlist) %></button><% end %></div>')
+    end
+
+    should 'disallow choose out of stock variants' do
+
+      SpreeVariantOptions::VariantConfig.allow_select_outofstock = false
+      SpreeVariantOptions::VariantConfig.default_instock = false
+
+
+      visit spree.product_path(@product)
+
+      # variant options are not selectable
+      within("#product-variants") do
+        size = find_link('S')
+        size.click
+        assert !size["class"].include?("selected")
+        color = find_link('Green')
+        color.click
+        assert !color["class"].include?("selected")
       end
 
-      should 'disallow choose out of stock variants' do
+      # add to cart button is still disabled
+      assert_equal "true", find_button("Add To Cart")["disabled"]
+      # add to wishlist button is still disabled
+      assert_equal "true", find_button("Add To Wishlist")["disabled"]
+    end
 
-        SpreeVariantOptions::VariantConfig.allow_select_outofstock = false
+    should 'allow choose out of stock variants' do
+      SpreeVariantOptions::VariantConfig.allow_select_outofstock = true
 
-        visit spree.product_path(@product)
+      visit spree.product_path(@product)
 
-        # variant options are not selectable
-        within("#product-variants") do
-          size = find_link('S')
-          size.click
-          assert !size["class"].include?("selected")
-          color = find_link('Green')
-          color.click
-          assert !color["class"].include?("selected")
-        end
+      # variant options are selectable
+      within("#product-variants") do
+        size = find_link('S')
+        size.click
+        assert size["class"].include?("selected")
+        color = find_link('Green')
+        color.click
+        assert color["class"].include?("selected")
+      end
+      # add to cart button is still disabled
+      assert_equal "true", find_button("Add To Cart")["disabled"]
+      # add to wishlist button is enabled
+      assert_equal "false", find_button("Add To Wishlist")["disabled"]
+    end
 
-        # add to cart button is still disabled
-        assert_equal "true", find_button("Add To Cart")["disabled"]
-        # add to wishlist button is still disabled
-        assert_equal "true", find_button("Add To Wishlist")["disabled"]
+    should "choose in stock variant" do
+      visit spree.product_path(@product)
+      within("#product-variants") do
+        size = find_link('M')
+        size.click
+        assert size["class"].include?("selected")
+        color = find_link('Green')
+        color.click
+        assert color["class"].include?("selected")
+      end
+      # add to cart button is enabled
+      assert_equal "false", find_button("Add To Cart")["disabled"]
+      # add to wishlist button is enabled
+      assert_equal "false", find_button("Add To Wishlist")["disabled"]
+    end
+
+    should "should select first instock variant when default_instock is true" do
+      SpreeVariantOptions::VariantConfig.default_instock = true
+
+      visit spree.product_path(@product)
+
+      within("#product-variants") do
+        size = find_link('M')
+        assert size["class"].include?("selected")
+        color = find_link('Green')
+        assert color["class"].include?("selected")
       end
 
-      should 'allow choose out of stock variants' do
-        SpreeVariantOptions::VariantConfig.allow_select_outofstock = true
-
-        visit spree.product_path(@product)
-
-        # variant options are selectable
-        within("#product-variants") do
-          size = find_link('S')
-          size.click
-          assert size["class"].include?("selected")
-          color = find_link('Green')
-          color.click
-          assert color["class"].include?("selected")
-        end
-        # add to cart button is still disabled
-        assert_equal "true", find_button("Add To Cart")["disabled"]
-        # add to wishlist button is enabled
-        assert_equal "false", find_button("Add To Wishlist")["disabled"]
-      end
-
-      should "choose in stock variant" do
-        visit spree.product_path(@product)
-        within("#product-variants") do
-          size = find_link('M')
-          size.click
-          assert size["class"].include?("selected")
-          color = find_link('Green')
-          color.click
-          assert color["class"].include?("selected")
-        end
-        # add to cart button is enabled
-        assert_equal "false", find_button("Add To Cart")["disabled"]
-        # add to wishlist button is enabled
-        assert_equal "false", find_button("Add To Wishlist")["disabled"]
+      # add to cart button is enabled
+      assert_equal "false", find_button("Add To Cart")["disabled"]
+      within("span.price.selling") do
+        assert page.has_content?("$35.99")
       end
     end
 
-
-    context 'without inventory tracking' do
-
-      setup do
-        reset_spree_preferences
-        Spree::Config[:track_inventory_levels] = false
-        Spree::Config[:allow_backorders] = false
-        @product = Factory(:product)
-        @size = Factory(:option_type)
-        @color = Factory(:option_type, :name => "Color")
-        @s = Factory(:option_value, :presentation => "S", :option_type => @size)
-        @red = Factory(:option_value, :name => "Color", :presentation => "Red", :option_type => @color)
-        @green = Factory(:option_value, :name => "Color", :presentation => "Green", :option_type => @color)
-        @variant1 = @product.variants.create(:option_values => [@s, @red], :price => 10, :cost_price => 5)
-        @variant2 = @product.variants.create(:option_values => [@s, @green], :price => 10, :cost_price => 5)
-      end
-
-        should "choose variant with track_inventory_levels to false" do
-
-          pending "selenium run timeout.. dont know why"
-          return
-          visit spree.product_path(@product)
-          within("#product-variants") do
-            size = find_link('S')
-            size.click
-            assert size["class"].include?("selected")
-            color = find_link('Red')
-            color.click
-            assert color["class"].include?("selected")
-          end
-          save_and_open_page
-          # add to cart button is enabled
-          assert_equal "false", find_button("Add To Cart")["disabled"]
-          # add to wishlist button is enabled
-          assert_equal "false", find_button("Add To Wishlist")["disabled"]
-        end
-      end
   end
+
+  context 'without inventory tracking' do
+
+    setup do
+      reset_spree_preferences
+      Spree::Config[:track_inventory_levels] = false
+      Spree::Config[:allow_backorders] = false
+      @product = Factory(:product)
+      @size = Factory(:option_type)
+      @color = Factory(:option_type, :name => "Color")
+      @s = Factory(:option_value, :presentation => "S", :option_type => @size)
+      @red = Factory(:option_value, :name => "Color", :presentation => "Red", :option_type => @color)
+      @green = Factory(:option_value, :name => "Color", :presentation => "Green", :option_type => @color)
+      @variant1 = @product.variants.create(:option_values => [@s, @red], :price => 10, :cost_price => 5)
+      @variant2 = @product.variants.create(:option_values => [@s, @green], :price => 10, :cost_price => 5)
+    end
+
+    should "choose variant with track_inventory_levels to false" do
+
+      pending "selenium run timeout.. dont know why"
+      return
+      visit spree.product_path(@product)
+      within("#product-variants") do
+        size = find_link('S')
+        size.click
+        assert size["class"].include?("selected")
+        color = find_link('Red')
+        color.click
+        assert color["class"].include?("selected")
+      end
+      save_and_open_page
+      # add to cart button is enabled
+      assert_equal "false", find_button("Add To Cart")["disabled"]
+      # add to wishlist button is enabled
+      assert_equal "false", find_button("Add To Wishlist")["disabled"]
+    end
+  end
+end

--- a/test/integration/variant_test.rb
+++ b/test/integration/variant_test.rb
@@ -116,6 +116,11 @@ class ProductTest < ActionDispatch::IntegrationTest
       end
     end
 
+    def teardown
+      # reset preferences to default values
+      SpreeVariantOptions::VariantConfig.allow_select_outofstock = false
+      SpreeVariantOptions::VariantConfig.default_instock = false
+    end
   end
 
   context 'without inventory tracking' do


### PR DESCRIPTION
hi @citrus,

This PR add a new configuration option : default_instock_variant.

I've updated the readme with the different configuration options.

Specs and cucumber features are green :beer:

Let me know if you have any questions.

Stephane.
