### PR TITLE
Add json_escape to to_json, fixes issues with &nbsp in price format.

### DIFF
--- a/app/views/spree/products/_variant_options.html.erb
+++ b/app/views/spree/products/_variant_options.html.erb
@@ -23,7 +23,7 @@
     <script type="text/javascript">
     //<![CDATA[
       var variant_options = new VariantOptions({
-        options: <%== @product.variant_options_hash.to_json -%>,
+        options: <%== j @product.variant_options_hash.to_json -%>,
         track_inventory_levels: <%==  !!Spree::Config[:track_inventory_levels] -%>,
         allow_backorders: <%==  !!Spree::Config[:allow_backorders] -%>,
         allow_select_outofstock: <%== !!SpreeVariantOptions::VariantConfig[:allow_select_outofstock] -%>,


### PR DESCRIPTION
Exemple issue: some currencies requires spacing like "10,00 $ CAD" but you don't want line break so number_to_currency format looks like "10,00%nbsp;$%nbsp;CA".
